### PR TITLE
Allocation improvements

### DIFF
--- a/src/main/java/team/chisel/ctm/client/util/RegionCache.java
+++ b/src/main/java/team/chisel/ctm/client/util/RegionCache.java
@@ -60,8 +60,8 @@ public class RegionCache implements BlockAndTintGetter {
         // We do NOT use getPassthrough() here so as to skip the null-validation - it's obviously valid to be null here
         if (this.passthrough.get() != passthrough) {
             stateCache.clear();
+            this.passthrough = new WeakReference<>(passthrough);
         }
-        this.passthrough = new WeakReference<>(passthrough);
         return this;
     }
 

--- a/src/main/java/team/chisel/ctm/client/util/RegionCache.java
+++ b/src/main/java/team/chisel/ctm/client/util/RegionCache.java
@@ -74,7 +74,14 @@ public class RegionCache implements BlockAndTintGetter {
     @Override
     public BlockState getBlockState(BlockPos pos) {
         long address = pos.asLong();
-        return stateCache.computeIfAbsent(address, a -> getPassthrough().getBlockState(pos));
+        var state = stateCache.get(address);
+
+        if (state == null) {
+            state = getPassthrough().getBlockState(pos);
+            stateCache.put(address, state);
+        }
+
+        return state;
     }
 
 	@Override


### PR DESCRIPTION
These ended up not being as impactful as I hoped, because the heaviest hitters (BlockPos allocations) are difficult to remove without a lot of refactoring which I didn't want to get into, or introducing threadlocals that could cause issues if connection methods are called recursively. However, still better than nothing.